### PR TITLE
Fixed numbered lists and missing language on code fence

### DIFF
--- a/html-css/lesson1.md
+++ b/html-css/lesson1.md
@@ -158,7 +158,7 @@ To manage conflicts, we will need a common code base in which all changes are co
 
 Now that you have the project set up on your computer, you need a place to safely make changes without effecting the common code base. To do this, we'll navigate to our project in the Terminal and create a new branch:
 
-```
+```bash
 cd <your-project-directory>
 git checkout -b my-first-branch
 ```
@@ -173,7 +173,7 @@ When you're done, run `git checkout my-first-branch` to go back to the branch wi
 
 Right now, your new branch only exists on your computer. Let's push it up to GitHub so you can see it in your profile.
 
-```
+```bash
 git checkout my-first-branch
 git push -u origin my-first-branch
 ```
@@ -242,20 +242,20 @@ If you're feeling confused, don't worry. Version control is one of the most diff
 # Resources
 
 1. [HTML5 - semantic elements](https://developer.mozilla.org/en/docs/Web/Guide/HTML/HTML5)
-2. [CSS Selectors - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors)
-3. [The Cascade - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade)
-4. [Box Model - MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Box_model)
-5. [Box Model, box-sizing: border-box - CSS Tricks](https://css-tricks.com/international-box-sizing-awareness-day/)
-6. [CSS specificity - MDN](https://developer.mozilla.org/en/docs/Web/CSS/Specificity)
-7. [Pseudo classes - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes)
+1. [CSS Selectors - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors)
+1. [The Cascade - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade)
+1. [Box Model - MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Box_model)
+1. [Box Model, box-sizing: border-box - CSS Tricks](https://css-tricks.com/international-box-sizing-awareness-day/)
+1. [CSS specificity - MDN](https://developer.mozilla.org/en/docs/Web/CSS/Specificity)
+1. [Pseudo classes - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes)
 
 ## Homework
 
 1. (Est. 2 hours) Read about [advanced CSS selectors](http://learn.shayhowe.com/advanced-html-css/complex-selectors/) and then practice by playing this [CSS selector game](https://flukeout.github.io/). It gets hard at the end, but try your best!
 
-2. Fork [the html-css-project repo](https://github.com/Code-Your-Future/html-css-project) and follow the instructions on the README -
+1. Fork [the html-css-project repo](https://github.com/Code-Your-Future/html-css-project) and follow the instructions on the README -
 
-3. You'll be put in groups of three. Over the next three weeks, you'll be asked to complete one of the [Starter Projects](https://github.com/CodeYourFuture/group-projects#starter-projects) as a group.
+1. You'll be put in groups of three. Over the next three weeks, you'll be asked to complete one of the [Starter Projects](https://github.com/CodeYourFuture/group-projects#starter-projects) as a group.
 
 (If you need help with Forking - then refer back to [this tutorial](https://help.github.com/articles/fork-a-repo/))
 

--- a/html-css/mentor-guide.md
+++ b/html-css/mentor-guide.md
@@ -218,33 +218,33 @@ documentation and picking up on minor details.
 A mentor should act as a `remote` repository and have a large sheet of paper.
 All students should have 4-5 sheets of paper.
 
-1 The teacher should write the word `master` at the top of the sheet, and write
+1. The teacher should write the word `master` at the top of the sheet, and write
    their name below that.
-2 All students should clone the main sheet on one of their sheets (`git
+1. All students should clone the main sheet on one of their sheets (`git
    clone`).
-3 All students should add their name to their `master` sheet. Then show it to
+1. All students should add their name to their `master` sheet. Then show it to
    the mentor (`git commit` and pull request).
-4 Take a moment to indicate how their sheets have diverged from the main sheet.
-5 All students should copy the mentor's `master` sheet (`git pull`).
-6 Ask two students to add a line to their sheet with any word they want. Then
+1. Take a moment to indicate how their sheets have diverged from the main sheet.
+1. All students should copy the mentor's `master` sheet (`git pull`).
+1. Ask two students to add a line to their sheet with any word they want. Then
    show it to the mentor (`git commit` and pull request). The mentor should
    refuse to merge one pull request.
-7 All students should copy the mentor's `master` sheet (`git pull`).
-8 The student who's pull request wasn't merged is now out-of-sync. Take a
+1. All students should copy the mentor's `master` sheet (`git pull`).
+1. The student who's pull request wasn't merged is now out-of-sync. Take a
    moment to describe the problem and introduce branching.
-9 Ask the students to take another sheet, and copy the `master` sheet,
+1. Ask the students to take another sheet, and copy the `master` sheet,
    replacing `master` with `feature-branch` (`git checkout -b feature-branch`).
-10 Replay 3-5, this time rejecting some of the pull requests. Then have them
+1. Replay 3-5, this time rejecting some of the pull requests. Then have them
     copy the additions to the mentor's `master` sheet (`git pull`).
-11 Have them destroy their `feature-branch` sheets (`git branch -D
+1. Have them destroy their `feature-branch` sheets (`git branch -D
     feature-branch`).
-12 Ask the students to take a new sheet of paper, and copy the `master` sheet,
+1. Ask the students to take a new sheet of paper, and copy the `master` sheet,
     replacing `master` with `update-branch` (`git checkout -b feature-branch`).
-13 Ask the students to add three names to their `update-branch` sheet.
-14 Ask the students to take a new sheet of paper, and copy only two of the
+1. Ask the students to add three names to their `update-branch` sheet.
+1. Ask the students to take a new sheet of paper, and copy only two of the
     three names they added to their `update-branch` sheet (`git add name1
     name2`).
-15 Take a moment to discuss the difference between the workspace and index.
+1. Take a moment to discuss the difference between the workspace and index.
     Then ask them to pass their commit sheet in.
 
 ## HTML Forms

--- a/html-css/week-01/lesson.md
+++ b/html-css/week-01/lesson.md
@@ -86,9 +86,9 @@ The example website you'll begin working with is available
 Fork the repository to your personal account and use the following terminal
 commands to download the files to your projects folder.
 
-1 `cd ~`
-2 `cd <your-project-directory>`
-3 `git clone git@github.com:<your_username>/bikes-for-refugees.git`
+1. `cd ~`
+1. `cd <your-project-directory>`
+1. `git clone git@github.com:<your_username>/bikes-for-refugees.git`
 
 > **Exercise**: Spend a few minutes exploring the `.html` and `.css` files for
 > this page. Why don't we put everything in one file?
@@ -264,12 +264,12 @@ showing a visible border.
 
 # Resources
 
-1 [HTML5 - semantic elements](https://developer.mozilla.org/en/docs/Web/Guide/HTML/HTML5)
-2 [CSS Selectors - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors)
-3 [The Cascade - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade)
-4 [Box Model - MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Box_model)
-5 [Box Model, box-sizing: border-box - CSS Tricks](https://css-tricks.com/international-box-sizing-awareness-day/)
-6 [CSS specificity - MDN](https://developer.mozilla.org/en/docs/Web/CSS/Specificity)
-7 [Pseudo classes - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes)
+1. [HTML5 - semantic elements](https://developer.mozilla.org/en/docs/Web/Guide/HTML/HTML5)
+1. [CSS Selectors - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors)
+1. [The Cascade - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade)
+1. [Box Model - MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Box_model)
+1. [Box Model, box-sizing: border-box - CSS Tricks](https://css-tricks.com/international-box-sizing-awareness-day/)
+1. [CSS specificity - MDN](https://developer.mozilla.org/en/docs/Web/CSS/Specificity)
+1. [Pseudo classes - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes)
 
 {% include "./homework.md" %}

--- a/js-core/week-04/homework.md
+++ b/js-core/week-04/homework.md
@@ -1,10 +1,10 @@
 # Homework
 
-1 [The repo](https://github.com/Code-Your-Future/JS-Core-1-Exercises) that you
+1. [The repo](https://github.com/Code-Your-Future/JS-Core-1-Exercises) that you
    have forked during this class contains few challenges - solve them in
    JavaScript!
 
-2 Follow
+1. Follow
    [this course](https://www.khanacademy.org/computing/computer-programming/programming)
    on Khan Academy. It will go through some of the basics that we covered in the
    class and beyond.

--- a/js-core/week-04/lesson.md
+++ b/js-core/week-04/lesson.md
@@ -39,15 +39,15 @@ A note on security: don't execute a script on your terminal if you don't
 trust its source, especially if they use the `sudo` command to get admin
 access to your machine.
 
-2 To test that it was installed and that it's running properly, go to your 
+1. To test that it was installed and that it's running properly, go to your 
  terminal and run the command: `node -v` You should get the node version printed 
  on your terminal, for example, `v8.9.3`
 
-3 Fork the 
+1. Fork the 
  [JS-Core-1-Exercises](https://github.com/CodeYourFuture/JS-Core-1-Exercises) 
  repository and **Clone** it locally.
 
-4 Once you have the repo locally, go to the folder on your terminal and run 
+1. Once you have the repo locally, go to the folder on your terminal and run 
   `node main.js`
 
 You should get **Hello World** printed on your Terminal.

--- a/js-core/week-06/homework.md
+++ b/js-core/week-06/homework.md
@@ -1,12 +1,12 @@
 # Homework
 
-1 Create an account on [CodeWars](http://www.codewars.com/) and do at least 15
+1. Create an account on [CodeWars](http://www.codewars.com/) and do at least 15
    challenges.
-2 Sign up for the [JavaScript 30](https://javascript30.com/) course and do at
+1. Sign up for the [JavaScript 30](https://javascript30.com/) course and do at
    least 2 project. You can find the starter files for the project [here](https://github.com/wesbos/JavaScript30)
 
 # Research
 
-1 [Closures](https://developer.mozilla.org/en/docs/Web/JavaScript/Closures)
-2 [*.call*, *.apply* and *.bind*](https://alexperry.io/personal/2016/04/03/How-to-use-apply-bind-and-call.html)
-3 [Higher-order functions](https://medium.com/functional-javascript/higher-order-functions-78084829fff4)
+1. [Closures](https://developer.mozilla.org/en/docs/Web/JavaScript/Closures)
+1. [*.call*, *.apply* and *.bind*](https://alexperry.io/personal/2016/04/03/How-to-use-apply-bind-and-call.html)
+1. [Higher-order functions](https://medium.com/functional-javascript/higher-order-functions-78084829fff4)

--- a/js-core/week-06/lesson.md
+++ b/js-core/week-06/lesson.md
@@ -75,8 +75,8 @@ Array and when do you use an Object.
 
 Let's talk about the differences between Arrays and Objects - when can you use or the other. As a general rule of thumb:
 
-1 Does the order of data matter? Then use Arrays.
-2 Can the data be organised by a label? Then use Objects.
+1. Does the order of data matter? Then use Arrays.
+1. Can the data be organised by a label? Then use Objects.
 
 > Exercise: Let's say we're writing a program to model and display a Newspaper:
 > what data structure would you use to model the different sections of the
@@ -437,7 +437,7 @@ console.log(test); // output: I'm global
 
 # Resources
 
-1 [Objects vs Arrays](https://www.metaltoad.com/blog/javascript-understanding-objects-vs-arrays-and-when-use-them-part-1)
-2 [JavaScript Arrays and Objects Are Just Like Books and Newspapers](https://medium.freecodecamp.org/javascript-arrays-and-objects-are-just-like-books-and-newspapers-6e1cbd8a1746)
+1. [Objects vs Arrays](https://www.metaltoad.com/blog/javascript-understanding-objects-vs-arrays-and-when-use-them-part-1)
+1. [JavaScript Arrays and Objects Are Just Like Books and Newspapers](https://medium.freecodecamp.org/javascript-arrays-and-objects-are-just-like-books-and-newspapers-6e1cbd8a1746)
 
 {% include "./homework.md" %}


### PR DESCRIPTION
I noticed that I broke some of the numbered lists when adding the markdown linting. I miss red the error message. Basically lists have to all start with .1 

For example

\1. first
\1. second
\1. third