### PR TITLE
Prevent deploys on PR branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ after_success:
   - eval "$(ssh-agent)"
   - chmod 600 ./cyf-key
   - ssh-add ./cyf-key
-  - ./publish-book.sh $TRAVIS_BRANCH
+  - ./publish-book.sh $TRAVIS_BRANCH $TRAVIS_PULL_REQUEST

--- a/publish-book.sh
+++ b/publish-book.sh
@@ -8,8 +8,12 @@ if [ "$#" -ne 1 ]; then
 	exit 1
 fi
 
-REPO_NAME="syllabus-$TRAVIS_BRANCH"
+if [[ ! $TRAVIS_BRANCH =~ ^(master|london|scotland)$ ]]; then
+	echo "Pushed to non-deployable branch. Stopping"
+	exit 1
+fi
 
+REPO_NAME="syllabus-$TRAVIS_BRANCH"
 
 git clone git@github.com:codeyourfuture/$REPO_NAME.git
 cp -a _book/* ./$REPO_NAME

--- a/publish-book.sh
+++ b/publish-book.sh
@@ -2,9 +2,15 @@
 
 DATE=$(date +%Y%m%d_%H%M%s)
 TRAVIS_BRANCH="$1"
+IS_TRAVIS_PR="$2"
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -ne 2 ]; then
 	echo "Please provide a branch (master, london, scotland)"
+	exit 1
+fi
+
+if [[ $IS_TRAVIS_PR -ne "false" ]]; then
+	echo "Pushed PR. Stopping"
 	exit 1
 fi
 


### PR DESCRIPTION
Don't push to codeyourfuture.github.io/syllabus-(master|scotland|london) unless branch is (master|scotland|london). Prevents accidental "deploys" to branches with PRs.