### PR TITLE
Spike out mentors notes

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -54,4 +54,7 @@
 
 * [Contributing](CONTRIBUTING.md)
 * [Lesson Template](/others/lesson-template.md)
-* [HTML/CSS Mentors guide](/html-css/mentor-guide.md)
+* HTML/CSS
+  * [Mentors guide](/html-css/mentor-guide.md)
+* JavaScript I
+  * [Week 4 - Hello JavaScript](/js-core/week-04/mentors.md)

--- a/js-core/week-04/lesson.md
+++ b/js-core/week-04/lesson.md
@@ -2,6 +2,8 @@
 
 # JavaScript Core I - 1
 
+[Mentor Notes](./mentors.md)
+
 **What we will learn today?**
 
 * [Install Node](#install-node)

--- a/js-core/week-04/mentors.md
+++ b/js-core/week-04/mentors.md
@@ -1,0 +1,3 @@
+# Mentor's Notes
+
+Some notes about JS1-1


### PR DESCRIPTION
As discussed on a call recently, we want to provide mentor's notes for each lesson. This PR does **not** contain any such notes, but spikes out an idea for being able to include mentor notes in the compiled html output. The key points are:

- The mentor guide is included as a top level link in `SUMMARY.md`. This is necessary to get gitbook to compile the markdown file into html and create a link to the page
- Because of the above, the mentors notes will appear in the navigation sidebar. To reduce confusion I've put the mentor guide link at the bottom
- Hopefully it's obvious that the mentors notes I've added is just a stub and will need to be extended with actual content 🙂 

I believe this hits the main constraints of:

- Being easily linkable
- Not being in another repo
- Easily editable (We believe that Github's inline editing tools may be good enough. Although this is yet to be tested on someone non-technical)