### PR TITLE
Fix broken links and clean up duplicate files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ bullets under the main README.
 
 ## A Lesson template
 
-Please check the [lesson template](lesson-template.md) and use it as a starting
+Please check the [lesson template](https://codeyourfuture.github.io/syllabus-london/others/lesson-template.html) and use it as a starting
 point for your new lessons.
 
 Each lesson should follow that format - starting with **what we will learn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ on the individual class. Also Point them to the version on your branch.
 
 A Gitbook for each branch is published automatically on each push:
 
-* [Master Syllabus](https://code-your-future.github.io/syllabus-master/)
+* [Master Syllabus](https://codeyourfuture.github.io/syllabus-master/)
 
 For your convenience, you can run Gitbook locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,8 @@ Mentors should point the students to the individual classes on Github (not the
 gitbook links) to allow them to get familiar with Git and Github, and to focus
 on the individual class. Also Point them to the version on your branch.
 
-* [London](https://code-your-future.github.io/syllabus-london/)
-* [Scotland](https://code-your-future.github.io/syllabus-scotland/)
+* [London](https://codeyourfuture.github.io/syllabus-london/)
+* [Scotland](https://codeyourfuture.github.io/syllabus-scotland/)
 
 ## Publish the Gitbook
 


### PR DESCRIPTION
⚠️ Don't merge yet  ⚠️
I've noticed that there are duplicate files that live both in the root folder and under `/other`. The menu of gitbook link to `/other` while some in-text links still point to the root files. I'll compare the files one by one and make sure that the latest version is in `/other` so that the duplicate files in the root folder can be removed.