### PR TITLE
Add Airtame installation instructions

### DIFF
--- a/lesson0.md
+++ b/lesson0.md
@@ -9,6 +9,7 @@
 * [Terminal](#terminal-basics)
 * [Git](#git)
 * [IDEs](#ide)
+* [Airtame](#airtame)
 * [Homework](#homework)
 
 ---
@@ -282,6 +283,39 @@ websites and see the differences between them and VS Code.
 
 * [Atom](https://atom.io/)
 * [Webstorm](https://www.jetbrains.com/webstorm/)
+
+## Airtame
+
+During our classes, Students and Mentors will share their code with the rest of the class using a tool
+called [Airtame](https://airtame.com/) to present their laptop screen wirelessly to the projector.
+The instructions below were tested on Ubuntu. Installion may differ on OSX. To install Airtame:
+
+* Download the version for your Operating System (OS) [here](https://airtame.com/download/).
+* In the Terminal, navigate to the directory you downloaded the file. For example,
+  if you downloaded Airtame to your `Downloads` directory:
+  `$ cd ~/Downloads`
+  The downloaded file should have `.tar.gz` extension. You can see the full name with
+  `$ ls airtame*`
+* Extract the file using
+  `$ tar -xzf <filename>` replacing `<filename>` with the name of the downloaded file.
+  The command above will extract the contents of the downloaded file into a directory of the same name.
+* Launch Airtame with the following command:
+  `$ ./<airtame-dir>/launch-airtame.sh` replacing `<airtame-dir>` with the directory created in the previous step.
+* Install Airtame with the following command:
+  `$ ./<airtame-dir>/install.sh`
+  This will create a shortcut (icon) so you can launch Airtame from your Applications
+
+### Common Issues
+
+If you have errors returned when executing `launch-airtame.sh` or `install.sh` you may need to install
+one or more missing libraries in your System. Check the error message and:
+
+* If it contains `libgtk-x11` as part of the message, then execute the following command:
+  `$ sudo apt-get install libgtk2.0`
+* If it contains `libgconf` as part of the message, then execute the following comand:
+  `$ sudo apt-get install libgconf2.0`
+
+For any other errors, contact the Mentors on Slack, including the error message you are facing.
 
 ## Homework
 

--- a/lesson0.md
+++ b/lesson0.md
@@ -288,9 +288,10 @@ websites and see the differences between them and VS Code.
 
 During our classes, Students and Mentors will share their code with the rest of the class using a tool
 called [Airtame](https://airtame.com/) to present their laptop screen wirelessly to the projector.
-The instructions below were tested on Ubuntu. Installion may differ on OSX. To install Airtame:
+The instructions below were tested on Ubuntu only. Installation will differ on Mac OSX.
+To install Airtame:
 
-* Download the version for your Operating System (OS) [here](https://airtame.com/download/).
+* Download the Airtame version for Ubuntu [here](https://airtame.com/download/).
 * In the Terminal, navigate to the directory you downloaded the file. For example,
   if you downloaded Airtame to your `Downloads` directory:
   `$ cd ~/Downloads`
@@ -315,7 +316,7 @@ one or more missing libraries in your System. Check the error message and:
 * If it contains `libgconf` as part of the message, then execute the following comand:
   `$ sudo apt-get install libgconf2.0`
 
-For any other errors, contact the Mentors on Slack, including the error message you are facing.
+For any other errors, contact the Mentors on Slack, including the error message from the Terminal.
 
 ## Homework
 


### PR DESCRIPTION
As we had some Students facing issues while trying to install Airtame, I'm adding the installation instructions (for Ubuntu only) to Lesson 0.
We can move to another place if Lesson 0 is not the correct place to put it.