### PR TITLE
React improvements

### DIFF
--- a/react/week-19/homework.md
+++ b/react/week-19/homework.md
@@ -2,5 +2,5 @@ Complete all of the lesson 1 exercises in the [cyf-hotel-react](https://github.c
 
 ### Prepare for the next class
 
-1. Follow the official [React tutorial](https://reactjs.org/tutorial/tutorial.html)
+1. Follow the official [React tutorial](https://reactjs.org/tutorial/tutorial.html) (up to the "Completing the Game" section)
 2. Watch the [Beginner's Guide to ReactJS](https://egghead.io/courses/the-beginner-s-guide-to-reactjs) on Egghead.io

--- a/react/week-19/homework.md
+++ b/react/week-19/homework.md
@@ -1,4 +1,5 @@
-Complete all of the lesson 1 exercises in the [cyf-hotel-react](https://github.com/CodeYourFuture/cyf-hotel-react#lesson-1) project.
+1. If you haven't already, complete the in-class exercises on your `pokedex` app
+2. Complete all of the lesson 1 exercises in the [cyf-hotel-react](https://github.com/CodeYourFuture/cyf-hotel-react#lesson-1) project
 
 ### Prepare for the next class
 

--- a/react/week-20/homework.md
+++ b/react/week-20/homework.md
@@ -1,7 +1,9 @@
-Complete all of the lesson 2 exercises in the [cyf-hotel-react](https://github.com/CodeYourFuture/cyf-hotel-react#lesson-2) project.
+1. If you haven't already, complete the in-class exercises on your `pokedex` app
+2. Complete all of the lesson 2 exercises in the [cyf-hotel-react](https://github.com/CodeYourFuture/cyf-hotel-react#lesson-2) project
 
 ### Prepare for the next class
 
-1. Read the [lifecycle page](https://reactjs.org/docs/state-and-lifecycle.html) on the official React documentation
-2. Read the [AJAX page](https://reactjs.org/docs/faq-ajax.html) on the official React documentation
-3. Watch [this video tutorial](https://www.youtube.com/watch?v=TxqqrNfgTto) on fetching data in React
+1. Finish reading the official [React tutorial](https://reactjs.org/tutorial/tutorial.html)
+2. Read the [lifecycle page](https://reactjs.org/docs/state-and-lifecycle.html) on the official React documentation
+3. Read the [AJAX page](https://reactjs.org/docs/faq-ajax.html) on the official React documentation
+4. Watch [this video tutorial](https://www.youtube.com/watch?v=TxqqrNfgTto) on fetching data in React

--- a/react/week-20/lesson.md
+++ b/react/week-20/lesson.md
@@ -297,6 +297,7 @@ This code has a bug! `this.state` is initialised as an empty object, and so `thi
 ```js
 class Counter extends Component {
   constructor(props) {
+    super(props);
     this.state = {
       count: props.count
     };

--- a/react/week-20/lesson.md
+++ b/react/week-20/lesson.md
@@ -292,30 +292,13 @@ class Counter extends Component {
 }
 ```
 
-This code has a bug! `this.state` is initialised as an empty object, and so `this.state.count` is undefined. We need to initialise it. We can do this by assigning the state class property: ([interactive example](https://codesandbox.io/s/1oyxx4lzz7)):
-
-```js
-class Counter extends Component {
-  state = {
-    count: 0
-  };
-
-  render() {
-    // ...
-  }
-}
-```
-
-This state *class property* is something you may not have seen before. It runs before anything else in the component, assigning our state to `this.state`. As we've just seen, state initialisation needs to be done before anything else, that's why we have to do it here.
-
-You may also see another style of initialising state, which is **exactly equivalent**, where the `constructor` method is run before everything else and assigns `this.state` like a normal variable:
+This code has a bug! `this.state` is initialised as an empty object, and so `this.state.count` is undefined. We need to initialise it from props. We can do this in the class constructor ([interactive example](https://codesandbox.io/s/1oyxx4lzz7)):
 
 ```js
 class Counter extends Component {
   constructor(props) {
-    super(props);
     this.state = {
-      count: 0
+      count: props.count
     };
   }
 
@@ -325,13 +308,13 @@ class Counter extends Component {
 }
 ```
 
-The first style is a bit simpler to remember than the second style, so we'll stick to that through the rest of the course.
-
 Now the counter component is "remembering" its count, however it is stuck at 0. Next we'll look at how we change what the component is remembering ([interactive example](https://codesandbox.io/s/n714vmyk5l)):
 
 ```js
 class Counter extends Component {
-  // ...
+  constructor(props) {
+    // ...
+  }
 
   increment = () => {
     this.setState({
@@ -372,7 +355,9 @@ This still isn't a particular useful application, because we can only still only
 
 ```js
 class Counter extends Component {
-  // ...
+  constructor(props) {
+    // ...
+  }
 
   increment = () => {
     this.setState(previousState => {
@@ -395,20 +380,21 @@ So when do we need to use a callback function for `this.setState`? If we are com
 Let's recap what we've learnt about React state:
 
 - State is one of the class component super powers - you must use a class component to use state
-- We initialise state by assigning the `state` class property to an object with whatever initial state we want (e.g. `{ something: 'hello' }`)
+- We initialise state in the `constructor` method by assigning the `this.state` variable to an object with whatever initial state we want (e.g. `{ something: 'hello' }`)
 - We can read or render state by using the `this.state` variable (e.g. `this.state.something`)
 - We can change state using the `this.setState()` method and by passing the piece of state we want to update (e.g. `this.setState({ something: 'hi' })`)
 - If we need to read the previous state to be able to calculate the new state, then we must use a callback function with `this.setState()` (e.g. `this.setState((previousState) => { return { something: previousState.something + 1 } })`)
 
 > **Exercise D**
 > Open the `pokedex` React application and open the `CaughtPokemon.js` file
-> 1. Set the initial state by assigning the `state` class property to an object. Then make the initial state have `caughtPokemon: 0`
-> 2. Change the `CaughtPokemon` component to render `this.state.caughtPokemon` instead of hard-coding 0. Do you expect anything to have changed in your web browser?
-> 3. Add a `<button>` with the text "Catch Pokemon" to the `CaughtPokemon` component
-> 4. Create an `catchPokemon` method within the `CaughtPokemon` class
-> 5. Add a `onClick` handler to the `<button>` we just created that will call the `catchPokemon` method
-> 6. Within the `catchPokemon` method, use `this.setState()` to change `caughtPokemon` to 1
-> 7. Update the `catchPokemon` method to increase the number of `caughtPokemon` by 1 every time the button is clicked (hint: we need to use the previous state to calculate the new state)
+> 1. Add a `constructor` method to the `CaughtPokemon` component and remember to handle `props` correctly (hint: `super(props)`)
+> 2. Set the initial state by assigning `this.state` in the `constructor` method to an object. Then make the initial state have 0 `caughtPokemon`
+> 3. Change the `CaughtPokemon` component to render `this.state.caughtPokemon` instead of hard-coding 0. Do you expect anything to have changed in your web browser?
+> 4. Add a `<button>` with the text "Catch Pokemon" to the `CaughtPokemon` component
+> 5. Create an `catchPokemon` method within the `CaughtPokemon` class
+> 6. Add a `onClick` handler to the `<button>` we just created that will call the `catchPokemon` method
+> 7. Within the `catchPokemon` method, use `this.setState()` to change `caughtPokemon` to 1
+> 8. Update the `catchPokemon` method to increase the number of `caughtPokemon` by 1 every time the button is clicked (hint: we need to use the previous state to calculate the new state)
 
 ### When do you use Props or State?
 

--- a/react/week-20/lesson.md
+++ b/react/week-20/lesson.md
@@ -306,6 +306,27 @@ class Counter extends Component {
 }
 ```
 
+This state *class property* is something you may not have seen before. It runs before anything else in the component, assigning our state to `this.state`. As we've just seen, state initialisation needs to be done before anything else, that's why we have to do it here.
+
+You may also see another style of initialising state, which is **exactly equivalent**, where the `constructor` method is run before everything else and assigns `this.state` like a normal variable:
+
+```js
+class Counter extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      count: 0
+    };
+  }
+
+  render() {
+    // ...
+  }
+}
+```
+
+The first style is a bit simpler to remember than the second style, so we'll stick to that through the rest of the course.
+
 Now the counter component is "remembering" its count, however it is stuck at 0. Next we'll look at how we change what the component is remembering ([interactive example](https://codesandbox.io/s/n714vmyk5l)):
 
 ```js

--- a/react/week-20/lesson.md
+++ b/react/week-20/lesson.md
@@ -292,15 +292,13 @@ class Counter extends Component {
 }
 ```
 
-This code has a bug! `this.state` is initialised as an empty object, and so `this.state.count` is undefined. We need to initialise it from props. We can do this in the class constructor ([interactive example](https://codesandbox.io/s/1oyxx4lzz7)):
+This code has a bug! `this.state` is initialised as an empty object, and so `this.state.count` is undefined. We need to initialise it. We can do this by assigning the state class property: ([interactive example](https://codesandbox.io/s/1oyxx4lzz7)):
 
 ```js
 class Counter extends Component {
-  constructor(props) {
-    this.state = {
-      count: props.count
-    };
-  }
+  state = {
+    count: 0
+  };
 
   render() {
     // ...
@@ -312,9 +310,7 @@ Now the counter component is "remembering" its count, however it is stuck at 0. 
 
 ```js
 class Counter extends Component {
-  constructor(props) {
-    // ...
-  }
+  // ...
 
   increment = () => {
     this.setState({
@@ -355,9 +351,7 @@ This still isn't a particular useful application, because we can only still only
 
 ```js
 class Counter extends Component {
-  constructor(props) {
-    // ...
-  }
+  // ...
 
   increment = () => {
     this.setState(previousState => {
@@ -380,21 +374,20 @@ So when do we need to use a callback function for `this.setState`? If we are com
 Let's recap what we've learnt about React state:
 
 - State is one of the class component super powers - you must use a class component to use state
-- We initialise state in the `constructor` method by assigning the `this.state` variable to an object with whatever initial state we want (e.g. `{ something: 'hello' }`)
+- We initialise state by assigning the `state` class property to an object with whatever initial state we want (e.g. `{ something: 'hello' }`)
 - We can read or render state by using the `this.state` variable (e.g. `this.state.something`)
 - We can change state using the `this.setState()` method and by passing the piece of state we want to update (e.g. `this.setState({ something: 'hi' })`)
 - If we need to read the previous state to be able to calculate the new state, then we must use a callback function with `this.setState()` (e.g. `this.setState((previousState) => { return { something: previousState.something + 1 } })`)
 
 > **Exercise D**
 > Open the `pokedex` React application and open the `CaughtPokemon.js` file
-> 1. Add a `constructor` method to the `CaughtPokemon` component and remember to handle `props` correctly (hint: `super(props)`)
-> 2. Set the initial state by assigning `this.state` in the `constructor` method to an object. Then make the initial state have 0 `caughtPokemon`
-> 3. Change the `CaughtPokemon` component to render `this.state.caughtPokemon` instead of hard-coding 0. Do you expect anything to have changed in your web browser?
-> 4. Add a `<button>` with the text "Catch Pokemon" to the `CaughtPokemon` component
-> 5. Create an `catchPokemon` method within the `CaughtPokemon` class
-> 6. Add a `onClick` handler to the `<button>` we just created that will call the `catchPokemon` method
-> 7. Within the `catchPokemon` method, use `this.setState()` to change `caughtPokemon` to 1
-> 8. Update the `catchPokemon` method to increase the number of `caughtPokemon` by 1 every time the button is clicked (hint: we need to use the previous state to calculate the new state)
+> 1. Set the initial state by assigning the `state` class property to an object. Then make the initial state have `caughtPokemon: 0`
+> 2. Change the `CaughtPokemon` component to render `this.state.caughtPokemon` instead of hard-coding 0. Do you expect anything to have changed in your web browser?
+> 3. Add a `<button>` with the text "Catch Pokemon" to the `CaughtPokemon` component
+> 4. Create an `catchPokemon` method within the `CaughtPokemon` class
+> 5. Add a `onClick` handler to the `<button>` we just created that will call the `catchPokemon` method
+> 6. Within the `catchPokemon` method, use `this.setState()` to change `caughtPokemon` to 1
+> 7. Update the `catchPokemon` method to increase the number of `caughtPokemon` by 1 every time the button is clicked (hint: we need to use the previous state to calculate the new state)
 
 ### When do you use Props or State?
 

--- a/react/week-21/homework.md
+++ b/react/week-21/homework.md
@@ -1,3 +1,4 @@
-Complete all of the lesson 3 exercises in the [cyf-hotel-react](https://github.com/CodeYourFuture/cyf-hotel-react#lesson-3) project.
-
-Try to complete the [Stretch Goal exercises](https://github.com/CodeYourFuture/cyf-hotel-react#stretch-goals).
+1. If you haven't already, complete the in-class exercises on your `pokedex` app
+2. Complete all of the lesson 3 exercises in the [cyf-hotel-react](https://github.com/CodeYourFuture/cyf-hotel-react#lesson-3) project
+3. Deploy your pokedex application on Netlify and share the link in the class Slack channel
+4. Try to complete the [Stretch Goal exercises](https://github.com/CodeYourFuture/cyf-hotel-react#stretch-goals) in the cyf-hotel-react homework

--- a/react/week-21/lesson.md
+++ b/react/week-21/lesson.md
@@ -44,12 +44,8 @@ class Counter extends Component {
 So far we've looked at components that are always rendered in the browser. However (and this is often the case in large applications), we might want to control whether components are shown or not. Let's look at a Toggle component ([interactive example](https://codesandbox.io/s/xmo8oo514)):
 
 ```js
-const IsShown = () => (
-  <p>I'm shown when true ✅</p>
-);
-
-const IsNotShown = () => (
-  <p>I'm shown when false ☑️</p>
+const Message = () => (
+  <p>I'm shown when this.state.isShown is true ✅</p>
 );
 
 class Toggle extends Component {
@@ -64,7 +60,7 @@ class Toggle extends Component {
   render() {
     return (
       <div>
-        {this.state.isShown ? <IsShown /> : <IsNotShown />}
+        {this.state.isShown ? <Message /> : null}
         <button onClick={this.toggle}>Toggle</button>
       </div>
     );
@@ -72,7 +68,7 @@ class Toggle extends Component {
 }
 ```
 
-If you open up dev tools, you will see that the element changes based on the `isShown` state. The hidden element is not hidden with CSS, it is actually removed from the DOM. This is important in larger applications as it can free up resources (CPU & memory) that aren't being used any more.
+If you open up dev tools, you will see that the element changes based on the `isShown` state. The hidden element is not hidden with CSS, it is actually removed from the DOM. This is because `this.state.isShown` is `false` which means the Toggle component returns `null` for that part of the JSX. If you return `null` in JSX then React will render nothing at all.
 
 ## The Circle of Life
 

--- a/react/week-21/lesson.md
+++ b/react/week-21/lesson.md
@@ -319,12 +319,9 @@ A popular pattern for building forms and collect user data is the *controlled co
 
 ```js
 class SimpleReminder extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      reminder: ""
-    };
-  }
+  state = {
+    reminder: ""
+  };
 
   handleChange = event => {
     this.setState({

--- a/react/week-21/lesson.md
+++ b/react/week-21/lesson.md
@@ -317,7 +317,7 @@ Modern web applications often involve interacting with forms such as creating an
 
 A popular pattern for building forms and collect user data is the *controlled component* pattern. A pattern is a repeated solution to a problem that is useful in multiple similar cases. Let's have a look at an example ([interactive example](https://codesandbox.io/s/4jq1yqy8kx)):
 
-```
+```js
 class SimpleReminder extends Component {
   constructor(props) {
     super(props);
@@ -354,7 +354,7 @@ In addition, instead of just saving the value of the input in the state, we coul
 
 Let's have a look at a more complex example where we want to build a form to let users enter information to create a personal account ([interactive example](https://codesandbox.io/s/m7p083zn6p)):
 
-```
+```js
 class CreateAccountForm extends Component {
   state = {
     username: "",

--- a/react/week-21/lesson.md
+++ b/react/week-21/lesson.md
@@ -16,9 +16,10 @@ Last week we looked at using props and state to create React components that cha
 
 ```js
 class Counter extends Component {
-  state = {
-    count: 0
-  };
+  constructor(props) {
+    super(props);
+    this.state = { count: 0 };
+  }
 
   increment = () => {
     this.setState((previousState) => {
@@ -49,9 +50,10 @@ const Message = () => (
 );
 
 class Toggle extends Component {
-  state = {
-    isShown: false
-  };
+  constructor(props) {
+    super(props);
+    this.state = { isShown: false };
+  }
 
   toggle = () => {
     this.setState({ isShown: !this.state.isShown });
@@ -96,10 +98,11 @@ class Lifecycle extends Component {
 
 > **Exercise A**
 > Open the `pokedex` application that we have been working on for the last 2 weeks and open the `CaughtPokemon.js` file
-> 1. Add a `componentDidMount` method to the `CaughtPokemon` component. Within this method add a `console.log('componentDidMount')`. You don't need to return anything from this method
-> 2. Repeat the same step above with the `componentDidUpdate` and `componentWillUnmount` methods
-> 3. Try interacting with the `CaughtPokemon` component in your web browser (clicking the button) while looking at the JavaScript console. What order do the logs appear?
-> 4. The `componentWillUnmount` method will never be called. Can you explain why?
+> 1. Add a `constructor` method to the `CaughtPokemon` component. Within this method add a `console.log('constructor')`
+> 2. Add a `componentDidMount` method to the `CaughtPokemon` component. Within this method add a `console.log('componentDidMount')`. You don't need to return anything from this method
+> 3. Repeat the same step above with the `componentDidUpdate` and `componentWillUnmount` methods
+> 4. Try interacting with the `CaughtPokemon` component in your web browser (clicking the button) while looking at the JavaScript console. What order do the logs appear?
+> 5. The `componentWillUnmount` method will never be called. Can you explain why?
 
 We'll now focus on a few of the lifecycle hooks and see how they are used.
 
@@ -120,10 +123,11 @@ To look at these in more detail, we'll create a Clock component in an exercise.
 import React, { Component } from 'react';
 
 class Time extends Component {
-  state = {
-    date: new Date()
-  };
-
+  constructor(props) {
+    super(props);
+    this.state = { date: new Date() };
+  }
+  
   tick = () => {
     console.log('tick');
     this.setState({
@@ -139,10 +143,11 @@ class Time extends Component {
 }
 
 class Clock extends Component {
-  state = {
-    isShowingClock: true
-  };
-
+  constructor(props) {
+    super(props);
+    this.state = { isShowingClock: true };
+  }
+  
   toggle = () => this.setState({ isShowingClock: !this.state.isShowingClock });
   
   render() {
@@ -192,10 +197,13 @@ This example isn't very useful! We can't use the data returned from the server i
 
 ```js
 class MartianPhotoFetcher extends Component {
-  state = {
-    imgSrc: null
-  };
-
+  constructor(props) {
+    super(props);
+    this.state = {
+      imgSrc: null
+    };
+  }
+  
   componentDidMount() {
     fetch(`https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/photos?earth_date=${this.props.date}`)
       .then(res => res.json())
@@ -214,16 +222,19 @@ class MartianPhotoFetcher extends Component {
 
 Now we can see the Martian photo that we fetched from the server!
 
-However we have a bit of a problem - when we first render the component, we don't have the photo `src` yet. We first have to initialise it to `null`. This shows us that we're missing something from our UI - a *loading status*.
+However we have a bit of a problem - when we first render the component, we don't have the photo `src` yet. We first have to initialise it to `null` in the constructor. This shows us that we're missing something from our UI - a *loading status*.
 
 Let's look at showing a different UI when the request is loading ([interactive example](https://codesandbox.io/s/93zr0xz32r)):
 
 ```js
 class MartianPhotoFetcher extends Component {
-  state = {
-    isLoading: true,
-    imgSrc: null
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoading: true,
+      imgSrc: null
+    };
+  }
   
   componentDidMount() {
     fetch(`https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/photos?earth_date=${this.props.date}&api_key=gnesiqnKCJMm8UTYZYi86ZA5RAnrO4TAR9gDstVb`)
@@ -296,20 +307,21 @@ render() {
 > **Exercise C**
 > Open the `pokedex` React application again and open the `src/BestPokemon.js` file
 > 1. If you haven't already, convert the `BestPokemon` component to a class component
-> 2. Set the initial state to have a key named `pokemonNames` that is assigned to `null` (hint: `state = {}`)
-> 3. Add a `componentDidMount` method to the component
-> 4. Within the `componentDidMount` method call the `fetch()` function with this URL: `https://pokeapi.co/api/v2/pokedex/1/`. What will this do?
-> 5. Add a `.then()` handler into the `fetch` function (hint: remember this needs to come immediately after the `fetch()` call) which converts the response from JSON (hint: `.then(res => res.json())`)
-> 6. Add a second `.then()` handler after the one we just added, where the callback function will receive an argument called `data`
-> 7. Within the second `.then()` callback function, log out the data that we just received (hint: `console.log(data.pokemon_entries[0].pokemon_species.name)`)
-> 8. Now change the `console.log()` to log out an array instead, with the first, fourth and seventh Pokemon (hint: `console.log([data.pokemon_entries[0].pokemon_species.name, data.pokemon_entries[3].pokemon_species.name, data.pokemon_entries[6].pokemon_species.name])`)
-> 9. Now again within the `.then()` callback function, call `this.setState()` to set the `pokemonNames` key and assign it to the array that we just logged out (you can copy/paste it)
-> 10. Inside the `render` method, remove the old `pokemonNames` variable and replace it with `this.state.pokemonNames`. What do you see in your web browser?
-> 11. Add an `isLoading` piece of state, which is initialised to `true`
-> 12. When calling `this.setState()` inside the `.then()` handler, also set `isLoading` to `false`
-> 13. In the `render` method check if `this.state.isLoading` is `true` and return a loading message (e.g. `<span>Loading...</span>`). Otherwise if `this.state.isLoading` is `false` then render the loop as we did before
-> 14. **(STRETCH GOAL)** Add some error handling which renders an error message
-> 15. **(STRETCH GOAL)** Explore the data returned from the API. See if you can show some more interesting Pokemon information in your app (hint: try `console.log`ging different data returned from the API)
+> 2. Create a `constructor` method (hint: remember to call `super(props)`)
+> 3. Set the initial state to have a key named `pokemonNames` that is assigned to `null`
+> 4. Add a `componentDidMount` method to the component
+> 5. Within the `componentDidMount` method call the `fetch()` function with this URL: `https://pokeapi.co/api/v2/pokedex/1/`. What will this do?
+> 6. Add a `.then()` handler into the `fetch` function (hint: remember this needs to come immediately after the `fetch()` call) which converts the response from JSON (hint: `.then(res => res.json())`)
+> 8. Add a second `.then()` handler after the one we just added, where the callback function will receive an argument called `data`
+> 9. Within the second `.then()` callback function, log out the data that we just received (hint: `console.log(data.pokemon_entries[0].pokemon_species.name)`)
+> 10. Now change the `console.log()` to log out an array instead, with the first, fourth and seventh Pokemon (hint: `console.log([data.pokemon_entries[0].pokemon_species.name, data.pokemon_entries[3].pokemon_species.name, data.pokemon_entries[6].pokemon_species.name])`)
+> 11. Now again within the `.then()` callback function, call `this.setState()` to set the `pokemonNames` key and assign it to the array that we just logged out (you can copy/paste it)
+> 12. Inside the `render` method, remove the old `pokemonNames` variable and replace it with `this.state.pokemonNames`. What do you see in your web browser?
+> 13. Add an `isLoading` piece of state, which is initialised to `true`
+> 14. When calling `this.setState()` inside the `.then()` handler, also set `isLoading` to `false`
+> 15. In the `render` method check if `this.state.isLoading` is `true` and return a loading message (e.g. `<span>Loading...</span>`). Otherwise if `this.state.isLoading` is `false` then render the loop as we did before
+> 16. **(STRETCH GOAL)** Add some error handling which renders an error message
+> 17. **(STRETCH GOAL)** Explore the data returned from the API. See if you can show some more interesting Pokemon information in your app (hint: try `console.log`ging different data returned from the API)
 
 ## Working with forms in React
 
@@ -319,9 +331,12 @@ A popular pattern for building forms and collect user data is the *controlled co
 
 ```js
 class SimpleReminder extends Component {
-  state = {
-    reminder: ""
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      reminder: ""
+    };
+  }
 
   handleChange = event => {
     this.setState({
@@ -353,11 +368,14 @@ Let's have a look at a more complex example where we want to build a form to let
 
 ```js
 class CreateAccountForm extends Component {
-  state = {
-    username: "",
-    email: "",
-    password: ""
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      username: "",
+      email: "",
+      password: ""
+    };
+  }
 
   handleChange = event => {
     this.setState({

--- a/react/week-21/lesson.md
+++ b/react/week-21/lesson.md
@@ -426,6 +426,10 @@ console.log(dynamicKeyObject); // => { key1: "value1" }
 ```
 
 
+## Further Reading
+
+There is a new update to React, which adds a new feature called *Hooks*. It allows you to access the special super powers of state and lifecycle in regular function components. There is an extensive guide in the [official React tutorial](https://reactjs.org/docs/hooks-intro.html).
+
 # Homework
 
 {% include "./homework.md" %}

--- a/react/week-21/lesson.md
+++ b/react/week-21/lesson.md
@@ -16,10 +16,9 @@ Last week we looked at using props and state to create React components that cha
 
 ```js
 class Counter extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { count: 0 };
-  }
+  state = {
+    count: 0
+  };
 
   increment = () => {
     this.setState((previousState) => {
@@ -54,10 +53,9 @@ const IsNotShown = () => (
 );
 
 class Toggle extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { isShown: false };
-  }
+  state = {
+    isShown: false
+  };
 
   toggle = () => {
     this.setState({ isShown: !this.state.isShown });
@@ -102,11 +100,10 @@ class Lifecycle extends Component {
 
 > **Exercise A**
 > Open the `pokedex` application that we have been working on for the last 2 weeks and open the `CaughtPokemon.js` file
-> 1. Add a `constructor` method to the `CaughtPokemon` component. Within this method add a `console.log('constructor')`
-> 2. Add a `componentDidMount` method to the `CaughtPokemon` component. Within this method add a `console.log('componentDidMount')`. You don't need to return anything from this method
-> 3. Repeat the same step above with the `componentDidUpdate` and `componentWillUnmount` methods
-> 4. Try interacting with the `CaughtPokemon` component in your web browser (clicking the button) while looking at the JavaScript console. What order do the logs appear?
-> 5. The `componentWillUnmount` method will never be called. Can you explain why?
+> 1. Add a `componentDidMount` method to the `CaughtPokemon` component. Within this method add a `console.log('componentDidMount')`. You don't need to return anything from this method
+> 2. Repeat the same step above with the `componentDidUpdate` and `componentWillUnmount` methods
+> 3. Try interacting with the `CaughtPokemon` component in your web browser (clicking the button) while looking at the JavaScript console. What order do the logs appear?
+> 4. The `componentWillUnmount` method will never be called. Can you explain why?
 
 We'll now focus on a few of the lifecycle hooks and see how they are used.
 
@@ -127,11 +124,10 @@ To look at these in more detail, we'll create a Clock component in an exercise.
 import React, { Component } from 'react';
 
 class Time extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { date: new Date() };
-  }
-  
+  state = {
+    date: new Date()
+  };
+
   tick = () => {
     console.log('tick');
     this.setState({
@@ -147,11 +143,10 @@ class Time extends Component {
 }
 
 class Clock extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { isShowingClock: true };
-  }
-  
+  state = {
+    isShowingClock: true
+  };
+
   toggle = () => this.setState({ isShowingClock: !this.state.isShowingClock });
   
   render() {
@@ -201,13 +196,10 @@ This example isn't very useful! We can't use the data returned from the server i
 
 ```js
 class MartianPhotoFetcher extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      imgSrc: null
-    };
-  }
-  
+  state = {
+    imgSrc: null
+  };
+
   componentDidMount() {
     fetch(`https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/photos?earth_date=${this.props.date}`)
       .then(res => res.json())
@@ -226,19 +218,16 @@ class MartianPhotoFetcher extends Component {
 
 Now we can see the Martian photo that we fetched from the server!
 
-However we have a bit of a problem - when we first render the component, we don't have the photo `src` yet. We first have to initialise it to `null` in the constructor. This shows us that we're missing something from our UI - a *loading status*.
+However we have a bit of a problem - when we first render the component, we don't have the photo `src` yet. We first have to initialise it to `null`. This shows us that we're missing something from our UI - a *loading status*.
 
 Let's look at showing a different UI when the request is loading ([interactive example](https://codesandbox.io/s/93zr0xz32r)):
 
 ```js
 class MartianPhotoFetcher extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isLoading: true,
-      imgSrc: null
-    };
-  }
+  state = {
+    isLoading: true,
+    imgSrc: null
+  };
   
   componentDidMount() {
     fetch(`https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/photos?earth_date=${this.props.date}&api_key=gnesiqnKCJMm8UTYZYi86ZA5RAnrO4TAR9gDstVb`)
@@ -311,21 +300,20 @@ render() {
 > **Exercise C**
 > Open the `pokedex` React application again and open the `src/BestPokemon.js` file
 > 1. If you haven't already, convert the `BestPokemon` component to a class component
-> 2. Create a `constructor` method (hint: remember to call `super(props)`)
-> 3. Set the initial state to have a key named `pokemonNames` that is assigned to `null`
-> 4. Add a `componentDidMount` method to the component
-> 5. Within the `componentDidMount` method call the `fetch()` function with this URL: `https://pokeapi.co/api/v2/pokedex/1/`. What will this do?
-> 6. Add a `.then()` handler into the `fetch` function (hint: remember this needs to come immediately after the `fetch()` call) which converts the response from JSON (hint: `.then(res => res.json())`)
-> 8. Add a second `.then()` handler after the one we just added, where the callback function will receive an argument called `data`
-> 9. Within the second `.then()` callback function, log out the data that we just received (hint: `console.log(data.pokemon_entries[0].pokemon_species.name)`)
-> 10. Now change the `console.log()` to log out an array instead, with the first, fourth and seventh Pokemon (hint: `console.log([data.pokemon_entries[0].pokemon_species.name, data.pokemon_entries[3].pokemon_species.name, data.pokemon_entries[6].pokemon_species.name])`)
-> 11. Now again within the `.then()` callback function, call `this.setState()` to set the `pokemonNames` key and assign it to the array that we just logged out (you can copy/paste it)
-> 12. Inside the `render` method, remove the old `pokemonNames` variable and replace it with `this.state.pokemonNames`. What do you see in your web browser?
-> 13. Add an `isLoading` piece of state, which is initialised to `true`
-> 14. When calling `this.setState()` inside the `.then()` handler, also set `isLoading` to `false`
-> 15. In the `render` method check if `this.state.isLoading` is `true` and return a loading message (e.g. `<span>Loading...</span>`). Otherwise if `this.state.isLoading` is `false` then render the loop as we did before
-> 16. **(STRETCH GOAL)** Add some error handling which renders an error message
-> 17. **(STRETCH GOAL)** Explore the data returned from the API. See if you can show some more interesting Pokemon information in your app (hint: try `console.log`ging different data returned from the API)
+> 2. Set the initial state to have a key named `pokemonNames` that is assigned to `null` (hint: `state = {}`)
+> 3. Add a `componentDidMount` method to the component
+> 4. Within the `componentDidMount` method call the `fetch()` function with this URL: `https://pokeapi.co/api/v2/pokedex/1/`. What will this do?
+> 5. Add a `.then()` handler into the `fetch` function (hint: remember this needs to come immediately after the `fetch()` call) which converts the response from JSON (hint: `.then(res => res.json())`)
+> 6. Add a second `.then()` handler after the one we just added, where the callback function will receive an argument called `data`
+> 7. Within the second `.then()` callback function, log out the data that we just received (hint: `console.log(data.pokemon_entries[0].pokemon_species.name)`)
+> 8. Now change the `console.log()` to log out an array instead, with the first, fourth and seventh Pokemon (hint: `console.log([data.pokemon_entries[0].pokemon_species.name, data.pokemon_entries[3].pokemon_species.name, data.pokemon_entries[6].pokemon_species.name])`)
+> 9. Now again within the `.then()` callback function, call `this.setState()` to set the `pokemonNames` key and assign it to the array that we just logged out (you can copy/paste it)
+> 10. Inside the `render` method, remove the old `pokemonNames` variable and replace it with `this.state.pokemonNames`. What do you see in your web browser?
+> 11. Add an `isLoading` piece of state, which is initialised to `true`
+> 12. When calling `this.setState()` inside the `.then()` handler, also set `isLoading` to `false`
+> 13. In the `render` method check if `this.state.isLoading` is `true` and return a loading message (e.g. `<span>Loading...</span>`). Otherwise if `this.state.isLoading` is `false` then render the loop as we did before
+> 14. **(STRETCH GOAL)** Add some error handling which renders an error message
+> 15. **(STRETCH GOAL)** Explore the data returned from the API. See if you can show some more interesting Pokemon information in your app (hint: try `console.log`ging different data returned from the API)
 
 ## Working with forms in React
 
@@ -372,14 +360,11 @@ Let's have a look at a more complex example where we want to build a form to let
 
 ```
 class CreateAccountForm extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      username: "",
-      email: "",
-      password: ""
-    };
-  }
+  state = {
+    username: "",
+    email: "",
+    password: ""
+  };
 
   handleChange = event => {
     this.setState({


### PR DESCRIPTION
A few minor changes to the React module, based on feedback from teaching London class 5. Summary of the changes:

- Remove `constructor` from examples/exercises with state initialisation. We found that this only added confusion. We ended up having to talk about class inheritance for a while, which a) doesn't help much with React understanding and b) isn't really what React uses classes for - classes are treated more like mixins. (I haven't updated the CodeSandboxes yet, but I can do that easily once this is merged)
- Improve the unmounting example by showing how React handles returning `null` in render instead of confusingly named component (`IsShown`/`IsNotShown`)
- Tweak homework instructions
- Provide a few more further reading links

I'm aware that this may have some conflicts with @llh1's [PR](https://github.com/CodeYourFuture/syllabus/pull/290), but happy to get that merged first and can then deal with the conflicts.