### PR TITLE
Update React learning objectives

### DIFF
--- a/react/archived-learning-objectives.md
+++ b/react/archived-learning-objectives.md
@@ -1,0 +1,11 @@
+# Archived learning objectives - React module
+
+### Class components
+
+- Convert a function component to a class component
+- Be able to set state using basic object style and based on previous state
+
+### Lifecycle
+
+- "Clean up" a component when it is unmounted
+- Use `componentDidMount` lifecycle method to trigger `fetch()`

--- a/react/archived-learning-objectives.md
+++ b/react/archived-learning-objectives.md
@@ -1,4 +1,4 @@
-# Archived learning objectives - React module
+# Archived Learning Objectives - React module
 
 ### Class components
 

--- a/react/overall-learning-objectives.md
+++ b/react/overall-learning-objectives.md
@@ -1,0 +1,31 @@
+# Overall Learning Objectives
+
+By the end of the three lessons & homework, students should be able to build a React application:
+
+- Written with components
+  - Appropriately composed/nested
+  - Split across multiple files
+- Uses props to pass values between components
+  - Data like numbers/strings/objects/arrays
+  - And functions for handling state changes
+- Uses state to react to user interaction
+  - E.g. a button can be clicked to increment a counter
+- That fetches data from an API
+  - Loading, success and error states are shown
+- Containing a form
+  - Form inputs that can be filled out by the user
+  - Can be submitted, triggering an update in the app
+
+<!-- TODO: use this to make a rubric? -->
+
+## Out of scope
+
+These topics are considered out-of-scope:
+
+- Object-Orientated JavaScript (classes/inheritance)
+  - Details of `extends`/`super()` are not necessary to use React (they are an implementation detail of `Component` class), so don't go out of the way to teach this
+- Redux
+  - Want to focus on learning and practising the basics of React, before introducing new concepts
+  - Learning Redux will be easier once confident with React
+- CSS-in-JS
+- In depth functional programming

--- a/react/overall-learning-objectives.md
+++ b/react/overall-learning-objectives.md
@@ -1,4 +1,4 @@
-# Overall Learning Objectives
+# Overall Learning Objectives - React module
 
 By the end of the three lessons & homework, students should be able to build a React application:
 
@@ -7,7 +7,7 @@ By the end of the three lessons & homework, students should be able to build a R
   - Split across multiple files
 - Uses props to pass values between components
   - Data like numbers/strings/objects/arrays
-  - And functions for handling state changes
+  - Functions as event handlers
 - Uses state to react to user interaction
   - E.g. a button can be clicked to increment a counter
 - That fetches data from an API
@@ -17,6 +17,11 @@ By the end of the three lessons & homework, students should be able to build a R
   - Can be submitted, triggering an update in the app
 
 <!-- TODO: use this to make a rubric? -->
+
+For advanced students, some further objectives would be:
+
+- Use class components instead of function components/Hooks
+- Explain why React state is used over plain old JavaScript variables
 
 ## Out of scope
 

--- a/react/week-1/learning-objectives.md
+++ b/react/week-1/learning-objectives.md
@@ -24,8 +24,3 @@
 ### Deployment
 
 - Build and deploy a React application (to Netlify/Now/Heroku/etc)
-
-### Out of scope
-
-- CSS-in-JS
-- In depth functional programming

--- a/react/week-1/learning-objectives.md
+++ b/react/week-1/learning-objectives.md
@@ -18,7 +18,7 @@
 ### Passing props
 
 - Pass values to components as React props
-  - Receive props in a component (both function and class components)
+  - Receive props in a function component
   - Pass functions as props and call them in child components
 
 ### Deployment

--- a/react/week-2/learning-objectives.md
+++ b/react/week-2/learning-objectives.md
@@ -24,6 +24,8 @@ Show some data from an API in a component.
 
 - Can explain why a loading state is necessary when fetching data as the result is not available on the initial render
 - Be able to trigger `fetch()` using the `useEffect()` callback
+  - Be able to an empty array (`[]`) as the 2nd dependencies argument
+  - Understand that this will be explained further in week 3
 - Be able to store data from a successful API call in state
   - And be able to explain that this causes a re-render
 - Be able to catch an unsuccessful API call, store the error in state and render an error message

--- a/react/week-2/learning-objectives.md
+++ b/react/week-2/learning-objectives.md
@@ -1,16 +1,27 @@
 ## Learning Objectives - React Week 2
 
-### Class components
-
-- Convert a function component to a class component
-
 ### Event Handlers
 
+React to user interaction via events.
+
 - Be able to pass functions to event handlers
+  - Log to the console when a button is clicked
 
 ### State
 
-- Create a simple counter component, demonstrating knowledge of React state
-  - Be able to initialise & render state variables
-  - Be able to set state using basic object style and based on previous state
+Create a simple counter component, demonstrating knowledge of React state.
+
+- Be able to use state variables
+  - Initialise with a value
+  - Render state variables to the screen
+  - Update with a new value
 - Identify when to use props or state
+
+### Data fetching
+
+Show some data from an API in a component.
+
+- Understand that the component will be rendered before data is available and handle this appropriately using a loading state
+- Be able to trigger `fetch()` using the appropriate method
+- Be able to store data from a successful API call in state, and be able to explain that this causes a re-render
+- Be able to catch an unsuccessful API call, store the error in state and render an error message

--- a/react/week-2/learning-objectives.md
+++ b/react/week-2/learning-objectives.md
@@ -14,7 +14,3 @@
   - Be able to initialise & render state variables
   - Be able to set state using basic object style and based on previous state
 - Identify when to use props or state
-
-### Out of scope
-
-- JavaScript classes/inheritance

--- a/react/week-2/learning-objectives.md
+++ b/react/week-2/learning-objectives.md
@@ -12,16 +12,18 @@ React to user interaction via events.
 Create a simple counter component, demonstrating knowledge of React state.
 
 - Be able to use state variables
-  - Initialise with a value
-  - Render state variables to the screen
-  - Update with a new value
+  - Initialise with a value with `useState(initialValue)`
+  - Destructure state variable into `[state, setState]`
+  - Render state variables to the view
+  - Update with a new value with `setState(newValue)`
 - Identify when to use props or state
 
 ### Data fetching
 
 Show some data from an API in a component.
 
-- Understand that the component will be rendered before data is available and handle this appropriately using a loading state
-- Be able to trigger `fetch()` using the appropriate method
-- Be able to store data from a successful API call in state, and be able to explain that this causes a re-render
+- Can explain why a loading state is necessary when fetching data as the result is not available on the initial render
+- Be able to trigger `fetch()` using the `useEffect()` callback
+- Be able to store data from a successful API call in state
+  - And be able to explain that this causes a re-render
 - Be able to catch an unsuccessful API call, store the error in state and render an error message

--- a/react/week-3/learning-objectives.md
+++ b/react/week-3/learning-objectives.md
@@ -8,3 +8,4 @@ TODO (needs some scoping out)
 
 - Create a simple form in React
   - Use the controlled component pattern
+- Use data from a submitted form to update the application

--- a/react/week-3/learning-objectives.md
+++ b/react/week-3/learning-objectives.md
@@ -12,6 +12,11 @@
 
 ### Forms
 
-- Create a simple form in React
-  - Use the controlled component pattern
+- Create a simple form in React using the controlled component pattern
+  - Initialise state with `useState()`
+  - Be able to set the input `value` to the state variable
+  - Explain why the input does not change when typing if `onChange` is not set
+  - Be able to update the state using an `onChange` handler
 - Use data from a submitted form to update the application
+  - Be able to handle an `onSubmit` event to the form
+  - Be able to collect the form state variables and use them (setting state, POST request)

--- a/react/week-3/learning-objectives.md
+++ b/react/week-3/learning-objectives.md
@@ -2,6 +2,7 @@
 
 ### Data fetching (advanced)
 
+- Can explain what the effect of unmounting a component
 - Cleaning up effects
   - Recognise when an effect could cause a memory leak
   - Be able to prevent an effect causing a memory leak using the unsubscribe function of `useEffect()`
@@ -13,9 +14,9 @@
 ### Forms
 
 - Create a simple form in React using the controlled component pattern
-  - Initialise state with `useState()`
+  - Can initialise state with `useState()`
   - Be able to set the input `value` to the state variable
-  - Explain why the input does not change when typing if `onChange` is not set
+  - Can explain why the input does not change when typing if `onChange` is not set
   - Be able to update the state using an `onChange` handler
 - Use data from a submitted form to update the application
   - Be able to handle an `onSubmit` event to the form

--- a/react/week-3/learning-objectives.md
+++ b/react/week-3/learning-objectives.md
@@ -15,8 +15,3 @@
 
 - Create a simple form in React
   - Use the controlled component pattern
-
-### Out of scope
-
-- Libraries in the React ecosystem e.g. Redux/MobX, React Router
-- React Hooks (for now)

--- a/react/week-3/learning-objectives.md
+++ b/react/week-3/learning-objectives.md
@@ -2,12 +2,13 @@
 
 ### Data fetching (advanced)
 
-TODO (needs further scoping out)
-
-Some initial ideas:
-
-- Cleaning up effects with unsubscribe function
-- Update `useEffect()` in response to prop changes using 2nd dependencies argument
+- Cleaning up effects
+  - Recognise when an effect could cause a memory leak
+  - Be able to prevent an effect causing a memory leak using the unsubscribe function of `useEffect()`
+- Allow effects to update in response to prop changes
+  - Explain why a component with an effect dependent on props is broken with empty `useEffect()` dependencies (`[]`)
+  - Be able to fix a component with an effect dependent on props using the `useEffect()` dependencies
+  - Can describe the "lifecycle" of a component with `useEffect()` when props change
 
 ### Forms
 

--- a/react/week-3/learning-objectives.md
+++ b/react/week-3/learning-objectives.md
@@ -1,15 +1,8 @@
 ## Learning Objectives - React Week 3
 
-### Lifecycle
+### Data fetching (advanced)
 
-- "Clean up" a component when it is unmounted
-
-### Data fetching
-
-- Show some data from an API in a component
-  - Understand that `render` will be called before data is available and handle this appropriately
-  - Use `componentDidMount` lifecycle method to trigger `fetch()`
-  - Be able to hold data, loading & error states and render correctly based on these
+TODO (needs some scoping out)
 
 ### Forms
 

--- a/react/week-3/learning-objectives.md
+++ b/react/week-3/learning-objectives.md
@@ -2,7 +2,12 @@
 
 ### Data fetching (advanced)
 
-TODO (needs some scoping out)
+TODO (needs further scoping out)
+
+Some initial ideas:
+
+- Cleaning up effects with unsubscribe function
+- Update `useEffect()` in response to prop changes using 2nd dependencies argument
 
 ### Forms
 


### PR DESCRIPTION
Updates learning objectives for the React module:

- Extracted an "overall" set of learning objectives that is higher level and so will hopefully survive further React API changes (e.g. suspense)
- Updated the existing "weekly" learning objectives to remove references to class components ahead of the migration to Hooks
  - Left part of the week 3 objectives as a TODO, since I'm working on scoping this out currently
- Moved unused class component learning objectives to an "archived" file for easier retrieval or usage in additional material for advanced students

Feedback welcome!

@LucyMac @nbogie @anthonytranDev 
