### PR TITLE
Add instructions on stopping create-react-app and installing stop-runaway-react-effects

### DIFF
--- a/react/week-1/lesson.md
+++ b/react/week-1/lesson.md
@@ -139,51 +139,8 @@ As you can see, this is much easier to read than both the straight `React.create
 
 ## Let's Create A React App
 
-The Facebook team behind React have created a tool to help you create and set up React projects. It is called [Create React App](https://create-react-app.dev/). It sets up files like we saw in the previous example, so that you don't have to.
-
-> **Exercise C**: Install & set up a Create React App by following the steps below
-
-```
-npx create-react-app pokedex
-cd pokedex
-```
-
-Open the `pokedex` directory in your editor. Notice that create-react-app has created a bunch of folders for you. We will be working with the `pokedex` application for the rest of the module.
-
-### Starting the app
-
-We have now installed a React application starter kit using a tool called Create-React-App. The official documentation is available [here](https://create-react-app.dev/docs/getting-started).
-
-To start running your application, open your terminal and run:
-
-```
-npm start
-```
-
-This does two things:
-
-1. Run a program on your computer that *watches* your files and updates your application when you make changes. It also runs some checks for common bugs or problems in your code. An error message will be shown in your browser if it detects that there is a problem
-2. Opens a web browser with a link to your React app so that you can develop and test the changes you made
-
-### Stopping the app
-
-You might notice that once you have run `npm start` your terminal will look different. This is because it is running the *watcher* program. If you have a slower computer we recommend that you *stop* the program when you are not using your React app.
-
-To stop the program, open your terminal and press `Ctrl-C` (it's the same on Windows, Mac & Linux). Unfortunately, closing your terminal will **not** stop the program from running.
-
-Once you have stopped running the program, your React app **will stop working**. To start it again, open your terminal and run `npm start`.
-
-### Installing stop-runaway-react-effects
-
-We need to install another package that will help us later in the module.
-
-| **Exercise** |
-| :--- |
-| 1. Stop the React app from running, by following the instructions above. |
-| 2. In your terminal, run: `npm install stop-runaway-react-effects` |
-| 3. Once this has this finished, open the `src/index.js` file in your editor. Don't worry about understanding the code in this file, we'll learn about it later. |
-| 4. Add an extra line **at the top of the file** with this code: `import 'stop-runaway-react-effects/hijack';`. If it is not on **line 1** of the file, it will **not** work. |
-| 5. Run `npm start` again to start the React app again. |
+> **Exercise**
+> If you have not already, follow [the instructions to create a React app](https://docs.codeyourfuture.io/students/guides/creating-a-react-app).
 
 ## React Components
 

--- a/react/week-1/lesson.md
+++ b/react/week-1/lesson.md
@@ -144,9 +144,7 @@ The Facebook team behind React have created a tool to help you create and set up
 > **Exercise C**: Install & set up a Create React App by following the steps below
 
 ```
-npm install -g create-react-app
-
-create-react-app pokedex
+npx create-react-app pokedex
 cd pokedex
 ```
 

--- a/react/week-1/lesson.md
+++ b/react/week-1/lesson.md
@@ -139,7 +139,7 @@ As you can see, this is much easier to read than both the straight `React.create
 
 ## Let's Create A React App
 
-The Facebook team behind React have created a tool to help you create and set up React projects. It is called [Create React App](https://github.com/facebook/create-react-app). It sets up files like we saw in the previous example, so that you don't have to.
+The Facebook team behind React have created a tool to help you create and set up React projects. It is called [Create React App](https://create-react-app.dev/). It sets up files like we saw in the previous example, so that you don't have to.
 
 > **Exercise C**: Install & set up a Create React App by following the steps below
 

--- a/react/week-1/lesson.md
+++ b/react/week-1/lesson.md
@@ -148,10 +148,32 @@ npm install -g create-react-app
 
 create-react-app pokedex
 cd pokedex
+```
+
+Open the `pokedex` directory in your editor. Notice that create-react-app has created a bunch of folders for you. We will be working with the `pokedex` application for the rest of the module.
+
+### Starting the app
+
+We have now installed a React application starter kit using a tool called Create-React-App. The official documentation is available [here](https://create-react-app.dev/docs/getting-started).
+
+To start running your application, open your terminal and run:
+
+```
 npm start
 ```
 
-The last command should open a web browser for you. This shows the application that we are going to be working on. Open the `pokedex` directory in your editor. Notice that create-react-app has created a bunch of folders for you. We will be working with the `pokedex` application for the rest of the module.
+This does two things:
+
+1. Run a program on your computer that *watches* your files and updates your application when you make changes. It also runs some checks for common bugs or problems in your code. An error message will be shown in your browser if it detects that there is a problem
+2. Opens a web browser with a link to your React app so that you can test it
+
+### Stopping the app
+
+You might notice that once you have run `npm start` your terminal will look different. This is because it is running the *watcher* program. If you have a slower computer we recommend that you *stop* the program when you are not using your React app.
+
+To stop the program, open your terminal and press `Ctrl-C` (it's the same on Windows, Mac & Linux). Unfortunately, closing your terminal will **not** stop the program from running.
+
+Once you have stopped running the program, your React app **will stop working**. To start it again, open your terminal and run `npm start`.
 
 ## React Components
 

--- a/react/week-1/lesson.md
+++ b/react/week-1/lesson.md
@@ -182,7 +182,7 @@ We need to install another package that will help us later in the module.
 | 1. Stop the React app from running, by following the instructions above. |
 | 2. In your terminal, run: `npm install stop-runaway-react-effects` |
 | 3. Once this has this finished, open the `src/index.js` file in your editor. Don't worry about understanding the code in this file, we'll learn about it later. |
-| 4. Add an extra line **at the top of the file** with this code: `import 'stop-runaway-react-effects/hijack';`. |
+| 4. Add an extra line **at the top of the file** with this code: `import 'stop-runaway-react-effects/hijack';`. If it is not on **line 1** of the file, it will **not** work. |
 | 5. Run `npm start` again to start the React app again. |
 
 ## React Components

--- a/react/week-1/lesson.md
+++ b/react/week-1/lesson.md
@@ -163,7 +163,7 @@ npm start
 This does two things:
 
 1. Run a program on your computer that *watches* your files and updates your application when you make changes. It also runs some checks for common bugs or problems in your code. An error message will be shown in your browser if it detects that there is a problem
-2. Opens a web browser with a link to your React app so that you can test it
+2. Opens a web browser with a link to your React app so that you can develop and test the changes you made
 
 ### Stopping the app
 

--- a/react/week-1/lesson.md
+++ b/react/week-1/lesson.md
@@ -173,6 +173,18 @@ To stop the program, open your terminal and press `Ctrl-C` (it's the same on Win
 
 Once you have stopped running the program, your React app **will stop working**. To start it again, open your terminal and run `npm start`.
 
+### Installing stop-runaway-react-effects
+
+We need to install another package that will help us later in the module.
+
+| **Exercise** |
+| :--- |
+| 1. Stop the React app from running, by following the instructions above. |
+| 2. In your terminal, run: `npm install stop-runaway-react-effects` |
+| 3. Once this has this finished, open the `src/index.js` file in your editor. Don't worry about understanding the code in this file, we'll learn about it later. |
+| 4. Add an extra line **at the top of the file** with this code: `import 'stop-runaway-react-effects/hijack';`. |
+| 5. Run `npm start` again to start the React app again. |
+
 ## React Components
 
 We looked at the beginning of the lesson at the concept of components. Now let's look at how components are made in React.

--- a/react/week-1/mentors.md
+++ b/react/week-1/mentors.md
@@ -21,8 +21,13 @@
   - Just React.createElement calls with syntax sugar
 - CRA exercise
   - This can take time as everyone is downloading from npm at the same time
+    - Consider asking students to install ahead of the class
   - CRA can consume a lot of resources (especially on older laptops) so emphasise stopping/starting
     - This is the first time that students will have encountered a daemon, so may need some explanation
+- Installing `stop-runaway-react-effects`
+  - A package to prevent accidental infinite `useEffect` loops
+  - It **must** be imported before the `react` import so that `useEffect` can be monkey-patched
+  - [Package docs](https://github.com/kentcdodds/stop-runaway-react-effects)
 - React components section
   - Originally this was written with class components first
     - However, students went home and googled and saw alternative syntaxes

--- a/react/week-1/mentors.md
+++ b/react/week-1/mentors.md
@@ -19,7 +19,10 @@
 - JSX section
   - Open the Babel REPL (https://babeljs.io/repl/) - demonstrate that there isn't any magic in JSX
   - Just React.createElement calls with syntax sugar
-- CRA exercise - can take time as everyone is downloading from npm at the same time
+- CRA exercise
+  - This can take time as everyone is downloading from npm at the same time
+  - CRA can consume a lot of resources (especially on older laptops) so emphasise stopping/starting
+    - This is the first time that students will have encountered a daemon, so may need some explanation
 - React components section
   - Originally this was written with class components first
     - However, students went home and googled and saw alternative syntaxes

--- a/react/week-1/mentors.md
+++ b/react/week-1/mentors.md
@@ -19,11 +19,14 @@
 - JSX section
   - Open the Babel REPL (https://babeljs.io/repl/) - demonstrate that there isn't any magic in JSX
   - Just React.createElement calls with syntax sugar
-- CRA exercise
-  - This can take time as everyone is downloading from npm at the same time
-    - Consider asking students to install ahead of the class
-  - CRA can consume a lot of resources (especially on older laptops) so emphasise stopping/starting
-    - This is the first time that students will have encountered a daemon, so may need some explanation
+- Installing Create-React-App
+  - This should be set as homework ahead of the lesson
+    - Saves time waiting for everyone to install
+    - Also saves CPU cycles on slower computers, which may affect video calls
+  - CRA can consume a lot of resources (especially on older laptops) so emphasize stopping/starting
+  - This is the first time that students will have encountered a file watcher/daemon background process
+    - So take some time to demonstrate how to start and stop the app
+    - Recommend that students with slower computers stop the app when they are not using it
 - Installing `stop-runaway-react-effects`
   - A package to prevent accidental infinite `useEffect` loops
   - It **must** be imported before the `react` import so that `useEffect` can be monkey-patched


### PR DESCRIPTION
Does exactly what it says on the tin.

### Stopping create-react-app

This is needed because CRA tends to consume a lot of resources on old laptops, so stopping when not needed is recommended. This is worse if they accidentally run multiple instances (e.g. in a closed background tab).

### Installing stop-runaway-react-effects

To help prevent a mistake with `useEffect` which causes an infinite loop, install [`stop-runaway-react-effects`](https://github.com/kentcdodds/stop-runaway-react-effects) which prevents this problem.