### PR TITLE
Add React cheatsheet to docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -47,6 +47,7 @@
 
 - [Compiling SCSS](/html-css/compile-scss-instructions.md)
 - [Coding 101](/others/coding-101.md)
+- [React Cheatsheet](/others/react-cheatsheet.md)
 
 ## Modules
 

--- a/others/react-cheatsheet.md
+++ b/others/react-cheatsheet.md
@@ -1,0 +1,5 @@
+# React Cheatseat
+
+This is a temporarily link to the [React Cheatsheet on Google Docs](https://docs.google.com/document/d/1Y2vCGZ6BZu4yix6EaU--67DfRrTbc6n_dwjbJ7n6kz4/edit?usp=sharing).
+
+This will be added as an inline document in this syllabus once the content has been finalised.


### PR DESCRIPTION
# What does this change?
Adds React Cheatsheet temporarily link document to a new page and links it in the syllabus.

Module: React
Week(s): 1, 2, 3

## Description

<!-- Add a description of what your PR changes here -->

[Rendered version](https://github.com/CodeYourFuture/syllabus/blob/react-cheatsheet-to-docs/others/react-cheatsheet.md)

@nbogie 

