### PR TITLE
Migrate teacher resources into CYF GoogleDrive

### DIFF
--- a/html-css/week-2/mentors.md
+++ b/html-css/week-2/mentors.md
@@ -9,6 +9,11 @@ This outline provides tips to help mentors guide students to the best answers or
 - [Week 2 - Flexbox & Media Queries [Google Slides] - 28/05/2020](https://docs.google.com/presentation/d/10Y7ev8w0OZSwuCDU3dUB3wertwVgRIwd0pWC5l5qS8Y/edit#slide=id.g854eaaa097_0_58)
   - Created by Birmingham
 
+## Articles
+
+- [History of Responsive Web Design](https://alistapart.com/article/responsive-web-design/)
+- [Most Common ViewPort Sizes](https://responsivedesign.is/develop/browser-feature-support/media-queries-for-common-device-breakpoints/)
+
 ## Responsive Web Design
 
 Devices to brainstorm together:

--- a/html-css/week-3/mentors.md
+++ b/html-css/week-3/mentors.md
@@ -2,10 +2,19 @@
 
 This outline provides tips to help mentors guide students to the best answers or outcomes for the lesson topics and exercises.
 
-## Quiz
+## Resources
+- [Bootstrap Demo](https://github.com/anthonytranDev/cyf-bootstrap)
+
+## Articles
+- [What is design system - Please scroll the bottom for explanation in the FAQs](
+https://enonic.com/blog/what-is-design-system)
+
+## Quizzes
 
 - [HTML/CSS Quick Quiz - 19/05/2020](https://drive.google.com/open?id=1_6kJSfIqY2f5iltyH_SUXyfeUGXRLZiGKcecATavByA)
   - Created by Scotland and Nate
+- [HTML/CSS Quick Quiz - 18/04/2020](https://drive.google.com/open?id=1x-5GVJMeSe-gauVC6rDOBAa--ltZJNPd5pE095zYmC4)
+  - Created by Manchester and Anthony Tran
 
 ## Open-source HTML/CSS Frameworks
 

--- a/js-core-1/week-1/mentors.md
+++ b/js-core-1/week-1/mentors.md
@@ -2,9 +2,10 @@
 
 ## Presentations
 
-- [Week 1 - JS Core 1 [Google Slides] - 01/05/2020](https://drive.google.com/open?id=1NFMenLrQ5B5UhU7HJAf9_xQxXHs2Md0pN3ENynuhjJ0)
+- [Week 1 - JS Core 1 [Google Slides] - 01/05/2020](https://drive.google.com/open?id=10rob7Nw6mEpA0h1wEZueVIF7doBZqlfY2twQEYlIse4)
+  - [Function demo](https://github.com/anthonytranDev/cyf-js-core-1-function-demo)
   - Created by Manchester and Anthony Tran
-- [Week 1 Midweek Catch-up - JS Core 1 [Google Slides] - 01/05/2020](https://docs.google.com/presentation/d/1oscN2HfvQMKFkkQ1UBfGhP274S6fPT9f02Ibys1OW1E/edit#slide=id.p)
+- [Week 1 Midweek Catch-up - JS Core 1 [Google Slides] - 01/05/2020](https://drive.google.com/open?id=1iyqMSJUhaDSIdRQeguqxt_GZwKCwFk4cvikZpwK5Emo)
   - Created by Scotland and Richard Darby
 
 ## Videos

--- a/js-core-1/week-2/mentors.md
+++ b/js-core-1/week-2/mentors.md
@@ -2,7 +2,7 @@
 
 ## Presentations
 
-- [Week 2 - JS Core 1 [Google Slides] - 01/05/2020](https://drive.google.com/open?id=1nsFWPSfdOm2JF9swMJahC43Rruc--UAtxJ9ATs4cO8I)
+- [Week 2 - JS Core 1 [Google Slides] - 01/05/2020](https://drive.google.com/open?id=1rVqH5A01wNlb674u5qEf57Ppe_ldTk5Ni4IuVP8LOzY)
   - Created by Manchester Volunteers
 
 ## Quiz

--- a/js-core-1/week-3/mentors.md
+++ b/js-core-1/week-3/mentors.md
@@ -2,7 +2,7 @@
 
 ## Presentations
 
-- [Week 3 - JS Core 1 [Google Slides] - 01/05/2020](https://drive.google.com/open?id=1QmAx-GEl-Rm1aNmdLfkjPhSFdPblPAa_JS_eVoSi-Vc)
+- [Week 3 - JS Core 1 [Google Slides] - 01/05/2020](https://drive.google.com/open?id=1q98KUoX5QQoFEDUl52hLxOnWkoCi2vGrehHjBBEnfdI)
   - Created by Manchester Volunteers
 
 ## Resources

--- a/js-core-2/week-1/mentors.md
+++ b/js-core-2/week-1/mentors.md
@@ -2,7 +2,7 @@
 
 ## Presentations
 
-- [Week 1 - JS Core 2 [Google Slides] - 14/05/2020](https://docs.google.com/presentation/d/1a6hXv7VawDnCmdjs1NijEbwkPkN3YuabZLvgu9QI5qQ/edit?usp=sharing)
+- [Week 1 - JS Core 2 [Google Slides] - 14/05/2020](https://drive.google.com/open?id=1BWpnFr-E_i5ryeaXIcwC4wjeRkgNLDs-Tvetdkg2zyA)
   - [Resources](https://github.com/Abdoulrazack95/Object-Lesson)
   - Created by Manchester and Abdoulrazack
 

--- a/js-core-2/week-2/mentors.md
+++ b/js-core-2/week-2/mentors.md
@@ -2,7 +2,7 @@
 
 ## Presentations
 
-- [Week 2 - JS Core 2 [Google Slides] - 26/05/2020](https://docs.google.com/presentation/d/1y2b-AfrR9uk4z7AVQC3LUofCWJvQ86Px6aOav-rcvcs/edit#slide=id.p)
+- [Week 2 - JS Core 2 [Google Slides] - 26/05/2020](https://drive.google.com/open?id=1BWpnFr-E_i5ryeaXIcwC4wjeRkgNLDs-Tvetdkg2zyA)
   - [Resources](https://github.com/Abdoulrazack95/dom-html)
   - Created by Manchester and Abdoulrazack
 


### PR DESCRIPTION
# What does this change?

- Update teacher resources links (presentations, quiz) in mentor notes because of having copied over to CYF's GoogleDrive.
- Add some extra links to articles and GitHub exercises used in class.

## Description

Teacher notes and quizzes have been migrated under to CYF's GoogleDrive in order to avoid losing ownerships inadvertently on valuable resources. 
- Presentions have been copied into `3 - Education/Lesson Resources` folder.
- Quizzes have been copied into `3 - Education/Module Quiz` folder.

In addition to document location changes, some extra resources have been linked to the mentor notes used in MCR class.

## Who needs to know about this?
@CodeYourFuture/manchester-mentors