### PR TITLE
Fix description of what `.querySelectorAll` returns

### DIFF
--- a/js-core-2/week-2/lesson.md
+++ b/js-core-2/week-2/lesson.md
@@ -85,7 +85,7 @@ document.querySelectorAll("p");
 ```
 
 Both `.querySelector` and `querySelectorAll` accept a CSS selector as an input.
-`.querySelector` selects only the first element it finds, `querySelectorAll` selects all elements (it returns an array).
+`.querySelector` selects only the first element it finds, `querySelectorAll` selects all elements (it returns a `NodeList`, which you can think of as being similar to an array; it is an ordered sequence of DOM elements which you can loop through like with an array. The difference is that many common array methods like `.map` or `.concat` can't be used on a `NodeList`).
 
 #### Preparation for exercises
 
@@ -201,7 +201,7 @@ paragraph.innerText = "How are you?"; // now we can see the text displaying on t
 ```
 
 We've been using `document.querySelector` to retrieve a single element.
-To retrieve an array of multiple elements (that match a specific class name for example, or a specific tag) we use `document.querySelectorAll`.
+To retrieve a list of multiple elements (that match a specific class name for example, or a specific tag) we use `document.querySelectorAll`.
 
 ```js
 //change the background of all the paragraph items on our page

--- a/js-core-2/week-2/lesson.md
+++ b/js-core-2/week-2/lesson.md
@@ -85,7 +85,7 @@ document.querySelectorAll("p");
 ```
 
 Both `.querySelector` and `querySelectorAll` accept a CSS selector as an input.
-`.querySelector` selects only the first element it finds, `querySelectorAll` selects all elements (it returns a `NodeList`, which you can think of as being similar to an array; it is an ordered sequence of DOM elements which you can loop through like with an array. The difference is that many common array methods like `.map` or `.concat` can't be used on a `NodeList`).
+`.querySelector` selects only the first element it finds, `querySelectorAll` selects all elements (it returns a `NodeList`, which you can think of as being similar to an array; it is an ordered sequence of DOM elements which you can loop through like with an array. The difference is that many common array methods like `.map` or `.concat` can't be used on a `NodeList`. To turn a `NodeList` into an array, you can use `Array.from`, e.g. `let elementArray = Array.from(document.querySelectorAll("div"));`).
 
 #### Preparation for exercises
 


### PR DESCRIPTION
# What does this change?

Module: JS2
Week(s): 2

## Description

I've changed the description of what `.querySelectorAll` returns to be slightly more accurate - it previously said that it returns an array when it actually returns an array-like `NodeList` which doesn't implement most of the array methods. I hope now it isn't too confusing by introducing an extra concept? My worry was that students might start trying to use `.map`, etc. on a `NodeList` and be confused when that fails.

[Rendered version](https://github.com/CodeYourFuture/syllabus/blob/EmilePW-fix-querySelectorAll-desc/js-core-2/week-2/lesson.md)


## Who needs to know about this?

@ChrisOwen101 
